### PR TITLE
Se agrega tarea para securizar ssh

### DIFF
--- a/oscap-redhat8.yml
+++ b/oscap-redhat8.yml
@@ -31,6 +31,12 @@
   vars:
     var_system_crypto_policy: !!str DEFAULT
   tasks:
+    - name: 'Set PermitRootLogin to no'
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^PermitRootLogin'
+        line: PermitRootLogin no
+
     - name: 'Set fact: Package manager reinstall command (dnf)'
       set_fact:
         package_manager_reinstall_cmd: dnf reinstall -y


### PR DESCRIPTION
Se agrega una tarea que cambia la configuración por defecto de sshd para no permitir el login como root.